### PR TITLE
Add the new line character at the end of each log

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,7 +129,8 @@ func log(level Level, fields map[string]interface{}, format string, args ...inte
 		}
 
 		// Write the message.
-		_, err = out.Write([]byte(msg))
+		msg = append(msg, '\n')
+		_, err = out.Write(msg)
 		if err != nil {
 			panic(fmt.Errorf("cannot write in %s logger :: %v", level, err))
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -122,6 +122,7 @@ func TestLogger(t *testing.T) {
 			tc.logger(tc.format, tc.args...)
 
 			expected := fmt.Sprintf(tc.format, tc.args...)
+			expected = expected + "\n"
 			actual := out.String()
 			require.Equal(t, expected, actual)
 		})
@@ -172,7 +173,7 @@ func TestDifferentOutputsByLevel(t *testing.T) {
 	}
 
 	for _, l := range logs {
-		require.Equal(t, l.msg, l.output.String())
+		require.Equal(t, l.msg+"\n", l.output.String())
 	}
 }
 


### PR DESCRIPTION
## What?

Fix to add the new line character at the end of each log

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.
